### PR TITLE
1.2: disable shelf for incognito windows too

### DIFF
--- a/eventPage.js
+++ b/eventPage.js
@@ -1,4 +1,4 @@
 chrome.downloads.setShelfEnabled(false);
-chrome.runtime.onStartup.addListener(function() {
+chrome.windows.onCreated.addListener(function() {
 	chrome.downloads.setShelfEnabled(false);
 });

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
 
   "name": "Download Shelf Disabler",
   "description": "Turns off Chrome's downloads shelf.",
-  "version": "1.1",
+  "version": "1.2",
   "icons": { "128": "icon128.png" },
 
   "background": {


### PR DESCRIPTION
The extension didn't work for incognito windows because the runtime.onStartup event doesn't fire for incognito profiles - see [https://developer.chrome.com/extensions/runtime#event-onStartup](https://developer.chrome.com/extensions/runtime#event-onStartup).